### PR TITLE
alphanumeric street number parsing support, removal of city-like street type names

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -22,7 +22,7 @@
     Hollywood & Vine, Los Angeles, CA, 90028
     Hollywood Blvd and Vine St, Los Angeles, CA, 90028
     Mission Street at Valencia Street, San Francisco, CA, 90028
-    
+
 ==== License
 
     Copyright (c) 2007 Riderway (Derrek Long, Nicholas Schlueter)
@@ -47,24 +47,24 @@
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==== Notes
-    If parts of the address are omitted from the original string 
+    If parts of the address are omitted from the original string
     the accessor will be nil in StreetAddress::US::Address.
-    
+
     Example:
     address = StreetAddress::US.parse("1600 Pennsylvania Ave, washington, dc")
     assert address.postal_code.nil?
-    
+
 ==== Acknowledgements
-    
+
     This gem is a near direct port of the perl module Geo::StreetAddress::US
     originally written by Schuyler D. Erle.  For more information see
     http://search.cpan.org/~sderle/Geo-StreetAddress-US-0.99/
-    
+
 =end
 
 module StreetAddress
   class US
-    VERSION = '1.0.5'
+    VERSION = '1.0.6'
     DIRECTIONAL = {
       "north" => "N",
       "northeast" => "NE",
@@ -442,9 +442,9 @@ module StreetAddress
       "wells" => "wls",
       "wy" => "way"
     }
-  
+
     STREET_TYPES_LIST = {}
-    STREET_TYPES.to_a.each do |item| 
+    STREET_TYPES.to_a.each do |item|
       STREET_TYPES_LIST[item[0]] = true
       STREET_TYPES_LIST[item[1]] = true
     end
@@ -512,7 +512,7 @@ module StreetAddress
     }
 
     STATE_NAMES = STATE_CODES.invert
-    
+
     STATE_FIPS = {
       "01" => "AL",
       "02" => "AK",
@@ -570,7 +570,7 @@ module StreetAddress
     }
 
     FIPS_STATES = STATE_FIPS.invert
-    
+
     class << self
       attr_accessor(
         :street_type_regexp,
@@ -578,7 +578,7 @@ module StreetAddress
         :fraction_regexp,
         :state_regexp,
         :city_and_state_regexp,
-        :direct_regexp, 
+        :direct_regexp,
         :zip_regexp,
         :corner_regexp,
         :unit_regexp,
@@ -588,9 +588,14 @@ module StreetAddress
         :informal_address_regexp
       )
     end
-      
+
+    ROUTES_LIKE_CITIES = %w(beach bottom bridge brook brooks camp canyon cape cliff cliffs fort forest ft garden glen
+                          green grove harbor island isle key lake la mission mount mountain mt pine port river spring
+                          union valley)
+    ROUTES_LIKE_CITIES.each { |k, v| STREET_TYPES_LIST.delete(k) }
+
     self.street_type_regexp = STREET_TYPES_LIST.keys.join("|")
-    self.number_regexp = '\d+-?\d*'
+    self.number_regexp = '[[:alpha:]]?[[:digit:]]+-?[[:alnum:]]*'
     self.fraction_regexp = '\d+\/\d+'
     self.state_regexp = STATE_CODES.to_a.join("|").gsub(/ /, "\\s")
     self.city_and_state_regexp = '
@@ -598,19 +603,19 @@ module StreetAddress
         ([^\d,]+?)\W+
         (' + state_regexp + ')
       )'
-      
-    self.direct_regexp = DIRECTIONAL.keys.join("|") + 
-      "|" + 
-      DIRECTIONAL.values.sort{ |a,b| 
-        b.length <=> a.length 
-      }.map{ |x| 
+
+    self.direct_regexp = DIRECTIONAL.keys.join("|") +
+      "|" +
+      DIRECTIONAL.values.sort{ |a,b|
+        b.length <=> a.length
+      }.map{ |x|
         f = x.gsub(/(\w)/, '\1.')
-        [Regexp::quote(f), Regexp::quote(x)] 
+        [Regexp::quote(f), Regexp::quote(x)]
       }.join("|")
     self.zip_regexp = '(\d{5})(?:-?(\d{4})?)'
     self.corner_regexp = '(?:\band\b|\bat\b|&|\@)'
     self.unit_regexp = '(?:(su?i?te|p\W*[om]\W*b(?:ox)?|dept|apt|apartment|ro*m|fl|unit|box)\W+|\#\W*)([\w-]+)'
-    self.street_regexp = 
+    self.street_regexp =
       '(?:
           (?:(' + direct_regexp + ')\W+
           (' + street_type_regexp + ')\b)
@@ -629,10 +634,10 @@ module StreetAddress
             (?:[^\w,]+(' + direct_regexp + ')\b)?
           )
         )'
-    self.place_regexp = 
+    self.place_regexp =
       '(?:' + city_and_state_regexp + '\W*)?
        (?:' + zip_regexp + ')?'
-    
+
     self.address_regexp =
       '\A\W*
         (' + number_regexp + ')\W*
@@ -641,7 +646,7 @@ module StreetAddress
         (?:' + unit_regexp + '\W+)?' +
         place_regexp +
       '\W*\Z'
-      
+
     self.informal_address_regexp =
       '\A\s*
         (' + number_regexp + ')\W*
@@ -656,14 +661,14 @@ module StreetAddress
     StreetAddress::US::Address or nil if the location cannot be parsed
 
     pass the arguement, :informal => true, to make parsing more lenient
-    
+
 ====example
     StreetAddress::US.parse('1600 Pennsylvania Ave Washington, DC 20006')
     or:
     StreetAddress::US.parse('Hollywood & Vine, Los Angeles, CA')
     or
     StreetAddress::US.parse("1600 Pennsylvania Ave", :informal => true)
-    
+
 =end
     class << self
       def parse(location, args = {})
@@ -671,19 +676,19 @@ module StreetAddress
           parse_intersection(location)
         elsif args[:informal]
           parse_address(location) || parse_informal_address(location)
-        else 
+        else
           parse_address(location);
         end
       end
 =begin rdoc
-    
+
     parses only an intersection and returnsan instance of
     StreetAddress::US::Address or nil if the intersection cannot be parsed
-    
+
 ====example
     address = StreetAddress::US.parse('Hollywood & Vine, Los Angeles, CA')
     assert address.intersection?
-    
+
 =end
       def parse_intersection(inter)
         regex = Regexp.new(
@@ -692,9 +697,9 @@ module StreetAddress
           street_regexp + '\W+' +
           place_regexp + '\W*\Z', Regexp::IGNORECASE + Regexp::EXTENDED
         )
-        
+
         return unless match = regex.match(inter)
-        
+
         normalize_address(
           StreetAddress::US::Address.new(
             :street => match[4] || match[9],
@@ -711,7 +716,7 @@ module StreetAddress
           )
         )
       end
-      
+
 =begin rdoc
 
     parses only an address and returnsan instance of
@@ -765,7 +770,7 @@ module StreetAddress
            )
         )
       end
-      
+
       private
       def normalize_address(addr)
         addr.state = normalize_state(addr.state) unless addr.state.nil?
@@ -781,7 +786,7 @@ module StreetAddress
         addr.unit_prefix.capitalize! unless addr.unit_prefix.nil?
         return addr
       end
-      
+
       def normalize_state(state)
         if state.length < 3
           state.upcase
@@ -789,13 +794,13 @@ module StreetAddress
           STATE_CODES[state.downcase]
         end
       end
-      
+
       def normalize_street_type(s_type)
         s_type.downcase!
         s_type = STREET_TYPES[s_type] || s_type if STREET_TYPES_LIST[s_type]
         s_type.capitalize
       end
-      
+
       def normalize_directional(dir)
         if dir.length < 3
           dir.upcase
@@ -806,34 +811,34 @@ module StreetAddress
     end
 
 =begin rdoc
-  
-    This is class returned by StreetAddress::US::parse, StreetAddress::US::parse_address 
+
+    This is class returned by StreetAddress::US::parse, StreetAddress::US::parse_address
     and StreetAddress::US::parse_intersection.  If an instance represents an intersection
     the attribute street2 will be populated.
-  
+
 =end
     class Address
       attr_accessor(
-        :number, 
-        :street, 
-        :street_type, 
-        :unit, 
-        :unit_prefix, 
-        :suffix, 
-        :prefix, 
-        :city, 
-        :state, 
-        :postal_code, 
-        :postal_code_ext, 
-        :street2, 
-        :street_type2, 
-        :suffix2, 
+        :number,
+        :street,
+        :street_type,
+        :unit,
+        :unit_prefix,
+        :suffix,
+        :prefix,
+        :city,
+        :state,
+        :postal_code,
+        :postal_code_ext,
+        :street2,
+        :street_type2,
+        :suffix2,
         :prefix2
       )
 
       def initialize(args)
-        args.keys.each do |attrib| 
-          self.send("#{attrib}=", args[attrib]) 
+        args.keys.each do |attrib|
+          self.send("#{attrib}=", args[attrib])
         end
         return
       end
@@ -886,7 +891,7 @@ module StreetAddress
         else
           if intersection?
             s += prefix + " " unless prefix.nil?
-            s += street 
+            s += street
             s += " " + street_type unless street_type.nil?
             s += " " + suffix unless suffix.nil?
             s += " and"
@@ -906,7 +911,7 @@ module StreetAddress
           end
         end
         return s
-      end  
+      end
     end
   end
 end

--- a/test/test_street_address.rb
+++ b/test/test_street_address.rb
@@ -10,6 +10,8 @@ class StreetAddressUsTest < Test::Unit::TestCase
     @addr4 = "1005 Gravenstein Hwy N, Sebastopol CA 95472"
     @addr5 = "PO BOX 450, Chicago IL 60657"
     @addr6 = "2730 S Veitch St #207, Arlington, VA 22206"
+    @addr7 = "W298N408 Kings Way Delafield, WI 53188"
+    @addr8 = "N4785 19th Avenue, Montello, WI 53949"
 
     @int1 = "Hollywood & Vine, Los Angeles, CA"
     @int2 = "Hollywood Blvd and Vine St, Los Angeles, CA"
@@ -97,7 +99,7 @@ class StreetAddressUsTest < Test::Unit::TestCase
     assert_equal addr.street2, nil
 
 
- 
+
     addr = StreetAddress::US.parse(@addr4)
     assert_equal addr.number, "1005"
     assert_equal addr.postal_code, "95472"
@@ -111,13 +113,31 @@ class StreetAddressUsTest < Test::Unit::TestCase
     assert_equal addr.street2, nil
     assert_equal addr.suffix, "N"
 
-  
+
     addr = StreetAddress::US.parse(@addr5)
     assert_equal addr, nil
-    
-    
+
+
     addr = StreetAddress::US.parse(@addr6)
     assert_equal("207", addr.unit)
+
+    addr = StreetAddress::US.parse(@addr7)
+    assert_equal addr.number, 'W298N408'
+    assert_equal addr.street, 'Kings'
+    assert_equal addr.prefix, nil
+    assert_equal addr.street2, nil
+    assert_equal addr.street_type, 'Way'
+    assert_equal addr.city, 'Delafield'
+    assert_equal addr.state, 'WI'
+    assert_equal addr.postal_code, '53188'
+
+    addr = StreetAddress::US.parse(@addr8)
+    assert_equal addr.number, 'N4785'
+    assert_equal addr.street, '19th'
+    assert_equal addr.street_type, 'Ave'
+    assert_equal addr.city, 'Montello'
+    assert_equal addr.state, 'WI'
+    assert_equal addr.postal_code, '53949'
 
     addr = StreetAddress::US.parse(@int1)
     assert_equal addr.city, "Los Angeles"
@@ -150,8 +170,8 @@ class StreetAddressUsTest < Test::Unit::TestCase
     assert_equal addr.intersection?, true
     assert_equal addr.street_type, "St"
     assert_equal addr.street_type2, "St"
-    
-    parseable = ["1600 Pennsylvania Ave Washington DC 20006", 
+
+    parseable = ["1600 Pennsylvania Ave Washington DC 20006",
           "1600 Pennsylvania Ave #400, Washington, DC, 20006",
           "1600 Pennsylvania Ave Washington, DC",
           "1600 Pennsylvania Ave #400 Washington DC",
@@ -165,7 +185,7 @@ class StreetAddressUsTest < Test::Unit::TestCase
           "Hollywood & Vine, Los Angeles, CA, 90028",
           "Hollywood Blvd and Vine St, Los Angeles, CA, 90028",
           "Mission Street at Valencia Street, San Francisco, CA, 90028"]
-    
+
     parseable.each do |location|
       assert_not_nil(StreetAddress::US.parse(location), location + " was not parse able")
     end


### PR DESCRIPTION
* add optionally appearing single alpha character at start of street number regexp to support aplhanumeric number ranges (Wisconsin, northern IL)
* remove city-like names from the street types list to avoid greedy matching of the street regex
* unit tests
* patch version bump